### PR TITLE
numpy v2 compatibility

### DIFF
--- a/src/simplemseed/seedcodec.py
+++ b/src/simplemseed/seedcodec.py
@@ -245,8 +245,7 @@ def decompress(
     # in case of record with no data points, ex detection blockette, which often have compression type
     # set to 0, which messes up the decompresser even though it doesn't matter since there is no data.
     if numSamples == 0:
-        dt = numpy.dtype(numpy.int32)
-        dt = dt.newbyteorder("<")
+        dt = numpy.dtype("<i4")
         return numpy.asarray([], dt)
 
     # switch (compressionType):

--- a/src/simplemseed/steim2.py
+++ b/src/simplemseed/steim2.py
@@ -509,4 +509,4 @@ def steimPackWord(diff: list[int], nbits: int, ndiff: int, bitmask: int, submask
         i += 1
     if submask != 0:
         val |= submask << 30
-    return val
+    return val.astype(numpy.int32)

--- a/src/simplemseed/steimframeblock.py
+++ b/src/simplemseed/steimframeblock.py
@@ -162,8 +162,7 @@ class SteimFrameBlock:
             self.currentFrame += 1
 
         pos = self.currentSteimFrame.pos  # word position
-        self.currentSteimFrame.word[pos] = word.astype(
-            self.currentSteimFrame.word.dtype)  # add word
+        self.currentSteimFrame.word[pos] = word  # add word
         self.addEncodingNibble(nibble)  # add nibble
         self.numSamples += samples
         pos += 1  # increment position in frame

--- a/src/simplemseed/steimframeblock.py
+++ b/src/simplemseed/steimframeblock.py
@@ -35,9 +35,7 @@ class SteimFrame:
     """
 
     def __init__(self):
-        self.word = numpy.zeros(16, dtype=numpy.dtype(numpy.int32)).newbyteorder(
-            ">"
-        )  # 16 32-byte words
+        self.word = numpy.zeros(16, dtype=">i4")  # 16 32-byte words
         self.pos = 0  # word position in frame (pos: 0 = W0, 1 = W1, etc...)
 
     def isEmpty(self):

--- a/src/simplemseed/steimframeblock.py
+++ b/src/simplemseed/steimframeblock.py
@@ -162,7 +162,8 @@ class SteimFrameBlock:
             self.currentFrame += 1
 
         pos = self.currentSteimFrame.pos  # word position
-        self.currentSteimFrame.word[pos] = word  # add word
+        self.currentSteimFrame.word[pos] = word.astype(
+            self.currentSteimFrame.word.dtype)  # add word
         self.addEncodingNibble(nibble)  # add nibble
         self.numSamples += samples
         pos += 1  # increment position in frame

--- a/tests/test_mseed3.py
+++ b/tests/test_mseed3.py
@@ -251,7 +251,7 @@ class TestMSeed3:
 
     def testCreateFromBigEndian(self):
         data = numpy.array([1, 256, 8755, -16245, 65000, -65000], dtype=numpy.dtype('<i4'))
-        bigdata = data.newbyteorder('>').byteswap()
+        bigdata = data.view(data.dtype.newbyteorder('>')).byteswap()
         assert(data.dtype.byteorder == '<'
                or (data.dtype.byteorder == '=' and sys.byteorder == 'little'))
         assert(bigdata.dtype.byteorder == '>')


### PR DESCRIPTION
The current main branch is not ready for numpy v2.

Aside from some rather trivial namespace changes, the main change to be aware of is [changes to up-/downcasting rules](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion).

The steim2 roundtrip test ran into one of these issues. The simplemseed code internally does computations on a mix of `uint32` and `int32` and numpy (both v1 and v2) is upcasting the result to `int64`. 64 bit items like that are internally then used in assignments into 32 bit arrays. In numpy v1, such assignments that would overflow were silently working and overflowing into negative numbers. In numpy v2, such an assignment that would overflow actually does exactly that and raise an `OverflowError`.

Long story short, @crotwell, my guess is that the test suite more than likely does not cover all potential cases of such overflow scenarios. The code should ideally be checked for all occasions where `uint32` and `int32` (or `uint32` and native Python integers etc etc) are used in combined computations and either these should be changed so that all members of a given computation share the same type or the result needs to be explicitly cast to the correct type.

I think the diff illustrates the problem. I wasn't entirely sure which way to "fix" the issue was best, since I'm also not well versed with bitwise operations and potential implications or the possible reasoning behind choosing `uint` types in some of the parts of the code.