### PR TITLE
Correct sequence value for mseed2

### DIFF
--- a/src/simplemseed/miniseed.py
+++ b/src/simplemseed/miniseed.py
@@ -156,11 +156,12 @@ class MiniseedHeader:
         sta = self.station.ljust(5).encode("UTF-8")
         loc = self.location.ljust(2).encode("UTF-8")
         chan = self.channel.ljust(3).encode("UTF-8")
+        seq = ("%06d" % self.sequence_number).encode("UTF-8")
         struct.pack_into(
             self.endianChar + "6scc5s2s3s2s",
             header,
             0,
-            EMPTY_SEQ,
+            seq,
             b"D",
             b" ",
             sta,
@@ -605,7 +606,7 @@ def unpackMiniseedHeader(recordBytes, endianChar=">"):
         timeCorr=timeCorr,
         dataOffset=dataOffset,
         blocketteOffset=blocketteOffset,
-        sequence_number=seq,
+        sequence_number=int(seq),
         dataquality=qualityChar,
     )
 


### PR DESCRIPTION
The sequence in mseed2 was being replaced by six spaces instead of number digits, i.e. "000001". I don't think the standard supports spaces there, these files were giving errors in Snuffler. So this change retains the original value.

Testing code:
```python
import simplemseed
with open("output.mseed2", "wb") as outms:
    with open("input.mseed2", "rb") as inms:
        for ms2rec in simplemseed.readMiniseed2Records(inms):
            outms.write(ms2rec.pack())
```
The files are now identical :partying_face: 

Noticed it when writing v2 packets into a ringserver using simpledali, just in case it happened to more people.